### PR TITLE
Fix packaging - changelog and format

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,10 @@
-pgbackman (1.1.0-1) unstable; urgency=low
+pgbackman (1.1.0) unstable; urgency=low
 
   * New release 1.1.0
 
  -- Rafael Martinez Guerrero <rafael@postgresql.org.es>  Sat, 08 Oct 2015 03:07:05 +0000
+
+pgbackman (1.0.0) unstable; urgency=low
 
   * Initial release 1.0.0
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -12,8 +12,12 @@ PGBACKMAN_LOGDIR=/var/log/pgbackman
 
 case "$1" in
     configure)
-	groupadd -f -r $PGBACKMAN_GROUP
-	useradd -m -N -g $PGBACKMAN_GROUP -r -d /var/lib/pgbackman -s /bin/bash -c "PostgreSQL Backup Manager" $PGBACKMAN_USER
+	if ! getent group $PGBACKMAN_GROUP > /dev/null; then
+	    groupadd -f -r $PGBACKMAN_GROUP
+        fi
+	if ! getent passwd $PGBACKMAN_GROUP > /dev/null; then
+	    useradd -m -N -g $PGBACKMAN_GROUP -r -d /var/lib/pgbackman -s /bin/bash -c "PostgreSQL Backup Manager" $PGBACKMAN_USER
+	fi
 
 	if [ -d "$PGBACKMAN_LOGDIR" ]
 	then

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (quilt)
+3.0 (native)


### PR DESCRIPTION
Since the debian packaging is integrated with the source code in a single tarball, it should use the native format instead of quilt.

Also fix the changelog, a line was missing.